### PR TITLE
AI Assistant: Add glassmorphic styling and blue color scheme

### DIFF
--- a/src/styles/classes.js
+++ b/src/styles/classes.js
@@ -2,83 +2,83 @@
 
 export const INPUT_CLASSES = {
   // Standard text/number inputs
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white bg-opacity-70 border border-blueglass-300 rounded-lg px-3 py-2 text-blueglass-900 focus:outline-none focus:ring-2 focus:ring-blueglass-500 focus:border-blueglass-500",
   
   // Small inputs (like quantity in attachments)
-  small: "w-16 bg-white border border-gray-300 rounded px-2 py-1 text-gray-900 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black placeholder-gray-400"
+  small: "w-16 bg-white bg-opacity-70 border border-blueglass-300 rounded px-2 py-1 text-blueglass-900 text-sm focus:outline-none focus:ring-1 focus:ring-blueglass-500 focus:border-blueglass-500 placeholder-blueglass-400"
 }
 
 export const SELECT_CLASSES = {
   // Standard dropdown selects
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white bg-opacity-70 border border-blueglass-300 rounded-lg px-3 py-2 text-blueglass-900 focus:outline-none focus:ring-2 focus:ring-blueglass-500 focus:border-blueglass-500",
   
   // Large selects (like country selector)
-  large: "w-full bg-white border border-gray-300 rounded-lg px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black"
+  large: "w-full bg-white bg-opacity-70 border border-blueglass-300 rounded-lg px-4 py-2 text-blueglass-900 focus:outline-none focus:ring-2 focus:ring-blueglass-500 focus:border-blueglass-500"
 }
 
 export const BUTTON_CLASSES = {
-  // Primary black button
-  primary: "w-full bg-black hover:bg-gray-800 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
+  // Primary blue button
+  primary: "w-full bg-blueglass-600 hover:bg-blueglass-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
   
   // Toggle button (inactive state)
-  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-gray-600 hover:text-gray-900",
+  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-blueglass-600 hover:text-blueglass-900",
   
   // Toggle button (active state)
-  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-black text-white shadow-sm"
+  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-blueglass-600 text-white shadow-sm"
 }
 
 export const CONTAINER_CLASSES = {
-  // Main card container
-  card: "bg-white rounded-lg p-6 shadow-sm border border-gray-200",
+  // Main card container with glassmorphic style
+  card: "bg-white bg-opacity-20 backdrop-blur-xs rounded-lg p-6 border border-blueglass-300 shadow-sm",
   
   // Sub-container (like attachment items)
-  subCard: "bg-gray-50 rounded-lg p-4 border border-gray-200",
+  subCard: "bg-white bg-opacity-10 backdrop-blur-xs rounded-lg p-4 border border-blueglass-200",
   
   // Small item containers (like breakdown items)
-  item: "bg-gray-50 rounded p-3 text-sm border border-gray-200",
+  item: "bg-white bg-opacity-10 rounded p-3 text-blueglass-900 border border-blueglass-200",
   
   // Toggle button container
-  toggleContainer: "flex bg-gray-100 rounded-lg p-1 border border-gray-200"
+  toggleContainer: "flex bg-blueglass-100 rounded-lg p-1 border border-blueglass-300"
 }
 
 export const TEXT_CLASSES = {
   // Main headings
-  heading: "text-xl font-semibold text-gray-900 mb-4",
+  heading: "text-xl font-semibold text-blueglass-900 mb-4",
   
   // Page title
-  title: "text-4xl font-bold text-gray-900 mb-2",
+  title: "text-4xl font-bold text-blueglass-900 mb-2",
   
   // Subtitle
-  subtitle: "text-gray-600",
+  subtitle: "text-blueglass-700",
   
   // Section labels
-  label: "block text-sm font-medium text-gray-700 mb-2",
+  label: "block text-sm font-medium text-blueglass-700 mb-2",
   
   // Sub-headings
-  subHeading: "font-medium text-gray-700 mb-2",
+  subHeading: "font-medium text-blueglass-700 mb-2",
   
   // Price text
-  price: "text-black font-semibold",
+  price: "text-blueglass-900 font-semibold",
   
   // Small descriptive text
-  description: "text-sm text-gray-600",
+  description: "text-sm text-blueglass-700",
   
   // Small detail text
-  detail: "text-gray-600 text-xs",
+  detail: "text-blueglass-700 text-xs",
   
   // Product/item names
-  itemName: "text-gray-900 font-medium",
+  itemName: "text-blueglass-900 font-medium",
   
   // SKU text
-  sku: "text-gray-900 font-mono text-xs font-medium",
+  sku: "text-blueglass-900 font-mono text-xs font-medium",
   
   // Placeholder/empty state text
-  placeholder: "text-gray-500 text-center"
+  placeholder: "text-blueglass-500 text-center"
 }
 
 export const LAYOUT_CLASSES = {
-  // Main page container
-  page: "min-h-screen bg-gray-50 p-4",
+  // Main page container with subtle blue gradient background
+  page: "min-h-screen bg-gradient-to-b from-blueglass-50 to-blueglass-100 p-4",
   
   // Content wrapper
   wrapper: "max-w-6xl mx-auto",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,25 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        blueglass: {
+          50: '#f0f9ff',
+          100: '#e0f2fe',
+          200: '#bae6fd',
+          300: '#7dd3fc',
+          400: '#38bdf8',
+          500: '#0ea5e9',
+          600: '#0284c7',
+          700: '#0369a1',
+          800: '#075985',
+          900: '#0c4a6e',
+        },
+      },
+      backdropBlur: {
+        xs: '2px',
+      },
+    },
   },
   plugins: [],
 } 


### PR DESCRIPTION
This pull request was created by the AI Assistant.

**Objective:** Add glassmorphic styling and blue color scheme

**Branch:** ai-dev/add-glassmorphic-styling-blue-color
**Iterations:** 13

**AI Summary:**
I have updated the styling classes to implement a glassmorphic effect with a blue color scheme. This includes semi-transparent backgrounds with backdrop blur, blue tinted borders, and blue text and button colors.

The tailwind.config.js was extended with a blue color palette and backdrop blur utility.

The main page background now has a subtle blue gradient, and containers and buttons use the blue glass style.

This completes the task of adding glassmorphic styling and a blue color scheme. If you want, I can help verify or further customize the styles. Otherwise, the task is complete.

Please review the changes before merging.