### PR TITLE
AI Assistant: Change the styling to be glassmorphic and change the color scheme to blue

### DIFF
--- a/src/styles/classes.js
+++ b/src/styles/classes.js
@@ -2,83 +2,83 @@
 
 export const INPUT_CLASSES = {
   // Standard text/number inputs
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white bg-opacity-20 backdrop-blur-md border border-blue-300 rounded-lg px-3 py-2 text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
   
   // Small inputs (like quantity in attachments)
-  small: "w-16 bg-white border border-gray-300 rounded px-2 py-1 text-gray-900 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black placeholder-gray-400"
+  small: "w-16 bg-white bg-opacity-20 backdrop-blur-md border border-blue-300 rounded px-2 py-1 text-blue-900 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 placeholder-blue-400"
 }
 
 export const SELECT_CLASSES = {
   // Standard dropdown selects
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white bg-opacity-20 backdrop-blur-md border border-blue-300 rounded-lg px-3 py-2 text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
   
   // Large selects (like country selector)
-  large: "w-full bg-white border border-gray-300 rounded-lg px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black"
+  large: "w-full bg-white bg-opacity-20 backdrop-blur-md border border-blue-300 rounded-lg px-4 py-2 text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 }
 
 export const BUTTON_CLASSES = {
-  // Primary black button
-  primary: "w-full bg-black hover:bg-gray-800 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
+  // Primary blue button
+  primary: "w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
   
   // Toggle button (inactive state)
-  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-gray-600 hover:text-gray-900",
+  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-blue-600 hover:text-blue-900",
   
   // Toggle button (active state)
-  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-black text-white shadow-sm"
+  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-blue-600 text-white shadow-sm"
 }
 
 export const CONTAINER_CLASSES = {
-  // Main card container
-  card: "bg-white rounded-lg p-6 shadow-sm border border-gray-200",
+  // Main card container with glassmorphic effect
+  card: "bg-white bg-opacity-20 backdrop-blur-md rounded-lg p-6 shadow-sm border border-blue-300",
   
-  // Sub-container (like attachment items)
-  subCard: "bg-gray-50 rounded-lg p-4 border border-gray-200",
+  // Sub-container (like attachment items) with glassmorphic effect
+  subCard: "bg-white bg-opacity-10 backdrop-blur-sm rounded-lg p-4 border border-blue-300",
   
-  // Small item containers (like breakdown items)
-  item: "bg-gray-50 rounded p-3 text-sm border border-gray-200",
+  // Small item containers (like breakdown items) with glassmorphic effect
+  item: "bg-white bg-opacity-10 backdrop-blur-sm rounded p-3 text-sm border border-blue-300",
   
   // Toggle button container
-  toggleContainer: "flex bg-gray-100 rounded-lg p-1 border border-gray-200"
+  toggleContainer: "flex bg-blue-100 bg-opacity-30 rounded-lg p-1 border border-blue-300"
 }
 
 export const TEXT_CLASSES = {
   // Main headings
-  heading: "text-xl font-semibold text-gray-900 mb-4",
+  heading: "text-xl font-semibold text-blue-900 mb-4",
   
   // Page title
-  title: "text-4xl font-bold text-gray-900 mb-2",
+  title: "text-4xl font-bold text-blue-900 mb-2",
   
   // Subtitle
-  subtitle: "text-gray-600",
+  subtitle: "text-blue-600",
   
   // Section labels
-  label: "block text-sm font-medium text-gray-700 mb-2",
+  label: "block text-sm font-medium text-blue-700 mb-2",
   
   // Sub-headings
-  subHeading: "font-medium text-gray-700 mb-2",
+  subHeading: "font-medium text-blue-700 mb-2",
   
   // Price text
-  price: "text-black font-semibold",
+  price: "text-blue-900 font-semibold",
   
   // Small descriptive text
-  description: "text-sm text-gray-600",
+  description: "text-sm text-blue-600",
   
   // Small detail text
-  detail: "text-gray-600 text-xs",
+  detail: "text-blue-600 text-xs",
   
   // Product/item names
-  itemName: "text-gray-900 font-medium",
+  itemName: "text-blue-900 font-medium",
   
   // SKU text
-  sku: "text-gray-900 font-mono text-xs font-medium",
+  sku: "text-blue-900 font-mono text-xs font-medium",
   
   // Placeholder/empty state text
-  placeholder: "text-gray-500 text-center"
+  placeholder: "text-blue-500 text-center"
 }
 
 export const LAYOUT_CLASSES = {
-  // Main page container
-  page: "min-h-screen bg-gray-50 p-4",
+  // Main page container with subtle blue background
+  page: "min-h-screen bg-blue-50 p-4",
   
   // Content wrapper
   wrapper: "max-w-6xl mx-auto",


### PR DESCRIPTION
This pull request was created by the AI Assistant.

**Objective:** Change the styling to be glassmorphic and change the color scheme to blue

**Branch:** ai-dev/change-styling-glassmorphic-change-color
**Iterations:** 19

**AI Summary:**
The main layout in App.jsx already uses the LAYOUT_CLASSES.page and LAYOUT_CLASSES.wrapper classes for the background and content wrapper. Since I updated LAYOUT_CLASSES.page to have a subtle blue background, the main layout is consistent with the new blue color scheme.

I have completed the changes to implement the glassmorphic styling and blue color scheme by updating the centralized style classes and ensuring the main layout uses these classes.

Task is complete.

Please review the changes before merging.