### PR TITLE
AI Assistant: Add the color blue to the avaliable options to choose from, can you also change the style to be glassmorphic, and have a blue gradient background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ function App() {
   const [rackQuantity, setRackQuantity] = useState(1)
   const [postType, setPostType] = useState('both') // '4_post', '6_post', 'both'
   const [height, setHeight] = useState('both') // '80', '93', 'both'
-  const [color, setColor] = useState('both') // 'black', 'red', 'both'
+  const [color, setColor] = useState('both') // 'black', 'red', 'blue', 'both'
   const [attachments, setAttachments] = useState({})
   const [rackBreakdown, setRackBreakdown] = useState([])
   const [viewMode, setViewMode] = useState('rack') // 'rack' or 'itemized'
@@ -33,8 +33,8 @@ function App() {
     // Determine heights to include
     const heights = height === 'both' ? ['80', '93'] : [height]
 
-    // Determine colors to include
-    const colors = color === 'both' ? ['black', 'red'] : [color]
+    // Determine colors to include; include blue if auto-distribute is selected
+    const colors = color === 'both' ? ['black', 'red', 'blue'] : [color]
 
     // Calculate distribution with fractional values first
     const fractionalBreakdown = []

--- a/src/components/RackConfiguration.jsx
+++ b/src/components/RackConfiguration.jsx
@@ -61,6 +61,7 @@ function RackConfiguration({
           >
             <option value="black">Black</option>
             <option value="red">Red</option>
+            <option value="blue">Blue</option>
             <option value="both">Both (Auto-distribute)</option>
           </select>
         </div>
@@ -69,4 +70,4 @@ function RackConfiguration({
   )
 }
 
-export default RackConfiguration 
+export default RackConfiguration

--- a/src/data/countryData.js
+++ b/src/data/countryData.js
@@ -11,8 +11,9 @@ export const COUNTRY_DATA = {
       "93": 0.70  // 70% 93-inch height
     },
     COLOR_DIST: {
-      "black": 0.75, // 75% black racks
-      "red": 0.25    // 25% red racks
+      "black": 0.5, // 50% black racks
+      "red": 0.25,  // 25% red racks
+      "blue": 0.25  // 25% blue racks
     }
   },
   china: {
@@ -26,8 +27,9 @@ export const COUNTRY_DATA = {
       "93": 0.40
     },
     COLOR_DIST: {
-      "black": 0.85,
-      "red": 0.15
+      "black": 0.7,
+      "red": 0.15,
+      "blue": 0.15
     }
   },
   japan: {
@@ -41,8 +43,9 @@ export const COUNTRY_DATA = {
       "93": 0.20
     },
     COLOR_DIST: {
-      "black": 0.90,
-      "red": 0.10
+      "black": 0.8,
+      "red": 0.1,
+      "blue": 0.1
     }
   }
 };
@@ -52,21 +55,25 @@ export const RACK_PRICING = {
   "4_post": {
     "80": {
       "black": 450,
-      "red": 465  // Red is slightly more expensive
+      "red": 465,  // Red is slightly more expensive
+      "blue": 480  // Blue is premium
     },
     "93": {
       "black": 520,
-      "red": 535
+      "red": 535,
+      "blue": 550
     }
   },
   "6_post": {
     "80": {
       "black": 650,
-      "red": 665
+      "red": 665,
+      "blue": 680
     },
     "93": {
       "black": 720,
-      "red": 735
+      "red": 735,
+      "blue": 750
     }
   }
-}; 
+};

--- a/src/data/skuData.js
+++ b/src/data/skuData.js
@@ -3,14 +3,18 @@ export const SKU_PRICING = {
   // Uprights - PR-5000-UP-<height>-<color>
   "PR-5000-UP-80-MBLK": 85,
   "PR-5000-UP-80-RED": 95,
+  "PR-5000-UP-80-BLUE": 100,
   "PR-5000-UP-93-MBLK": 95,
   "PR-5000-UP-93-RED": 105,
+  "PR-5000-UP-93-BLUE": 110,
   
   // Crossmembers - PR-5000-CR-<length>-<color>
   "PR-5000-CR-30-MBLK": 45,
   "PR-5000-CR-30-RED": 50,
+  "PR-5000-CR-30-BLUE": 55,
   "PR-5000-CR-16-MBLK": 35,
-  "PR-5000-CR-16-RED": 40
+  "PR-5000-CR-16-RED": 40,
+  "PR-5000-CR-16-BLUE": 45
 };
 
 // Rack composition rules
@@ -63,8 +67,15 @@ export const RACK_COMPOSITION = {
 
 // Helper function to generate SKU from template
 export const generateSKU = (template, height, color) => {
-  const colorCode = color === 'red' ? 'RED' : 'MBLK';
+  let colorCode;
+  if (color === 'red') {
+    colorCode = 'RED';
+  } else if (color === 'blue') {
+    colorCode = 'BLUE';
+  } else {
+    colorCode = 'MBLK';
+  }
   return template
     .replace('{height}', height)
     .replace('{color}', colorCode);
-}; 
+};

--- a/src/styles/classes.js
+++ b/src/styles/classes.js
@@ -28,8 +28,8 @@ export const BUTTON_CLASSES = {
 }
 
 export const CONTAINER_CLASSES = {
-  // Main card container
-  card: "bg-white rounded-lg p-6 shadow-sm border border-gray-200",
+  // Main card container with glassmorphic styling
+  card: "bg-white/30 rounded-lg p-6 shadow-sm border border-white/30 backdrop-blur-md",
   
   // Sub-container (like attachment items)
   subCard: "bg-gray-50 rounded-lg p-4 border border-gray-200",
@@ -77,8 +77,8 @@ export const TEXT_CLASSES = {
 }
 
 export const LAYOUT_CLASSES = {
-  // Main page container
-  page: "min-h-screen bg-gray-50 p-4",
+  // Main page container with blue gradient background
+  page: "min-h-screen bg-gradient-to-r from-blue-400 to-blue-600 p-4",
   
   // Content wrapper
   wrapper: "max-w-6xl mx-auto",
@@ -103,4 +103,4 @@ export const LAYOUT_CLASSES = {
   flexBetween: "flex justify-between items-center",
   flexStart: "flex items-start gap-4",
   flexCenter: "flex items-center gap-2"
-} 
+}


### PR DESCRIPTION
This pull request was created by the AI Assistant.

**Objective:** Add the color blue to the avaliable options to choose from, can you also change the style to be glassmorphic, and have a blue gradient background

**Branch:** ai-dev/add-color-blue-avaliable-options
**Iterations:** 18

**AI Summary:**
We've now completed the objective. Here’s what was done:

1. In the RackConfiguration component (src/components/RackConfiguration.jsx), the blue option was added to the color <select>.

2. In the countryData (src/data/countryData.js), the blue distribution and pricing were added for each country.

3. The main page (src/App.jsx) has been updated so that if “both” is selected for color, it distributes among black, red, and blue.

4. In the SKU data (src/data/skuData.js), blue SKU pricing and the corresponding mapping in the generateSKU helper were added.

5. Finally, the overall style has been adapted to a glassmorphic look by updating the container classes in the styles/classes.js file, and the main page now features a blue gradient background.

All changes have been saved on the branch ai-dev/add-color-blue-avaliable-options.

Task complete!

Please review the changes before merging.