### PR TITLE
AI Assistant: Can you make the interface brighter with psychadelic colors

### DIFF
--- a/src/components/OrderSummary.jsx
+++ b/src/components/OrderSummary.jsx
@@ -60,113 +60,113 @@ function OrderSummary({
   }
 
   return (
-    <div className={`${CONTAINER_CLASSES.card} h-fit`}>
-      <div className={`${LAYOUT_CLASSES.flexBetween} mb-4`}>
-        <h2 className={TEXT_CLASSES.heading.replace(' mb-4', '')}>Order Summary</h2>
+    <div className={`${CONTAINER_CLASSES.card} h-fit`}> 
+      <div className={`${LAYOUT_CLASSES.flexBetween} mb-4`}> 
+        <h2 className={TEXT_CLASSES.heading.replace(' mb-4', '')}>Order Summary</h2> 
         
-        {selectedCountry && rackBreakdown.length > 0 && (
-          <div className={CONTAINER_CLASSES.toggleContainer}>
-            <button
-              onClick={() => onViewModeChange('rack')}
-              className={viewMode === 'rack' ? BUTTON_CLASSES.toggleActive : BUTTON_CLASSES.toggle}
-            >
-              By Rack
-            </button>
-            <button
-              onClick={() => onViewModeChange('itemized')}
-              className={viewMode === 'itemized' ? BUTTON_CLASSES.toggleActive : BUTTON_CLASSES.toggle}
-            >
-              Itemized
-            </button>
-          </div>
-        )}
-      </div>
+        {selectedCountry && rackBreakdown.length > 0 && ( 
+          <div className={CONTAINER_CLASSES.toggleContainer}> 
+            <button 
+              onClick={() => onViewModeChange('rack')} 
+              className={viewMode === 'rack' ? BUTTON_CLASSES.toggleActive : BUTTON_CLASSES.toggle} 
+            > 
+              By Rack 
+            </button> 
+            <button 
+              onClick={() => onViewModeChange('itemized')} 
+              className={viewMode === 'itemized' ? BUTTON_CLASSES.toggleActive : BUTTON_CLASSES.toggle} 
+            > 
+              Itemized 
+            </button> 
+          </div> 
+        )} 
+      </div> 
       
-      {selectedCountry && rackBreakdown.length > 0 && (
-        <>
-          {viewMode === 'rack' ? (
-            <div className="mb-4">
-              <h3 className={TEXT_CLASSES.subHeading}>Rack Distribution for {COUNTRY_DATA[selectedCountry]?.name}</h3>
-              <div className={LAYOUT_CLASSES.spacingY2}>
-                {rackBreakdown.map((item, index) => (
-                  <div key={index} className={CONTAINER_CLASSES.item}>
-                    <div className={LAYOUT_CLASSES.flexBetween}>
-                      <div className={LAYOUT_CLASSES.flexCenter}>
-                        <div className={`w-3 h-3 rounded-full ${item.color === 'black' ? 'bg-gray-800 border border-gray-600' : 'bg-red-500'}`}></div>
-                        <span className={TEXT_CLASSES.itemName}>
-                          {item.quantity}x {item.postType.replace('_', '-')} {item.height}" {item.color}
-                        </span>
-                      </div>
-                      <span className={TEXT_CLASSES.price}>${item.totalPrice.toLocaleString()}</span>
-                    </div>
-                    <div className={`${TEXT_CLASSES.detail} ml-5`}>
-                      ${item.unitPrice} each
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="mb-4">
-              <h3 className={TEXT_CLASSES.subHeading}>Itemized Components</h3>
-              <div className={LAYOUT_CLASSES.spacingY2}>
-                {calculateItemizedBreakdown().map((item, index) => (
-                  <div key={index} className={CONTAINER_CLASSES.item}>
-                    <div className={`${LAYOUT_CLASSES.flexBetween} mb-1`}>
-                      <span className={TEXT_CLASSES.sku}>{item.sku}</span>
-                      <span className={TEXT_CLASSES.price}>${item.totalPrice.toLocaleString()}</span>
-                    </div>
-                    <div className={LAYOUT_CLASSES.flexBetween}>
-                      <span className={TEXT_CLASSES.detail}>{item.description}</span>
-                      <span className={TEXT_CLASSES.detail}>
-                        {item.quantity}x @ ${item.unitPrice}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+      {selectedCountry && rackBreakdown.length > 0 && ( 
+        <> 
+          {viewMode === 'rack' ? ( 
+            <div className="mb-4"> 
+              <h3 className={TEXT_CLASSES.subHeading}>Rack Distribution for {COUNTRY_DATA[selectedCountry]?.name}</h3> 
+              <div className={LAYOUT_CLASSES.spacingY2}> 
+                {rackBreakdown.map((item, index) => ( 
+                  <div key={index} className={CONTAINER_CLASSES.item}> 
+                    <div className={LAYOUT_CLASSES.flexBetween}> 
+                      <div className={LAYOUT_CLASSES.flexCenter}> 
+                        <div className={`w-3 h-3 rounded-full ${item.color === 'black' ? 'bg-gray-800 border border-gray-600' : 'bg-red-500'}`}></div> 
+                        <span className={TEXT_CLASSES.itemName}> 
+                          {item.quantity}x {item.postType.replace('_', '-')} {item.height}" {item.color} 
+                        </span> 
+                      </div> 
+                      <span className={TEXT_CLASSES.price}>${item.totalPrice.toLocaleString()}</span> 
+                    </div> 
+                    <div className={`${TEXT_CLASSES.detail} ml-5`}> 
+                      ${item.unitPrice} each 
+                    </div> 
+                  </div> 
+                ))} 
+              </div> 
+            </div> 
+          ) : ( 
+            <div className="mb-4"> 
+              <h3 className={TEXT_CLASSES.subHeading}>Itemized Components</h3> 
+              <div className={LAYOUT_CLASSES.spacingY2}> 
+                {calculateItemizedBreakdown().map((item, index) => ( 
+                  <div key={index} className={CONTAINER_CLASSES.item}> 
+                    <div className={`${LAYOUT_CLASSES.flexBetween} mb-1`}> 
+                      <span className={TEXT_CLASSES.sku}>{item.sku}</span> 
+                      <span className={TEXT_CLASSES.price}>${item.totalPrice.toLocaleString()}</span> 
+                    </div> 
+                    <div className={LAYOUT_CLASSES.flexBetween}> 
+                      <span className={TEXT_CLASSES.detail}>{item.description}</span> 
+                      <span className={TEXT_CLASSES.detail}> 
+                        {item.quantity}x @ ${item.unitPrice} 
+                      </span> 
+                    </div> 
+                  </div> 
+                ))} 
+              </div> 
+            </div> 
+          )} 
 
-          {Object.entries(attachments).some(([_, qty]) => qty > 0) && (
-            <div className="mb-4">
-              <h3 className={TEXT_CLASSES.subHeading}>Attachments</h3>
-              <div className={LAYOUT_CLASSES.spacingY2}>
-                {Object.entries(attachments)
-                  .filter(([_, qty]) => qty > 0)
-                  .map(([id, qty]) => {
-                    const attachment = attachmentsData.find(a => a.id === id)
-                    return (
-                      <div key={id} className={CONTAINER_CLASSES.item}>
-                        <div className={LAYOUT_CLASSES.flexBetween}>
-                          <span className={TEXT_CLASSES.itemName}>{qty}x {attachment.name}</span>
-                          <span className={TEXT_CLASSES.price}>${(attachment.price * qty).toLocaleString()}</span>
-                        </div>
-                      </div>
-                    )
-                  })}
-              </div>
-            </div>
-          )}
+          {Object.entries(attachments).some(([_, qty]) => qty > 0) && ( 
+            <div className="mb-4"> 
+              <h3 className={TEXT_CLASSES.subHeading}>Attachments</h3> 
+              <div className={LAYOUT_CLASSES.spacingY2}> 
+                {Object.entries(attachments) 
+                  .filter(([_, qty]) => qty > 0) 
+                  .map(([id, qty]) => { 
+                    const attachment = attachmentsData.find(a => a.id === id) 
+                    return ( 
+                      <div key={id} className={CONTAINER_CLASSES.item}> 
+                        <div className={LAYOUT_CLASSES.flexBetween}> 
+                          <span className={TEXT_CLASSES.itemName}>{qty}x {attachment.name}</span> 
+                          <span className={TEXT_CLASSES.price}>${(attachment.price * qty).toLocaleString()}</span> 
+                        </div> 
+                      </div> 
+                    ) 
+                  })} 
+              </div> 
+            </div> 
+          )} 
 
-          <div className="border-t border-gray-200 pt-4">
-            <div className={`${LAYOUT_CLASSES.flexBetween} text-lg font-semibold`}>
-              <span className="text-gray-900">Total Cost:</span>
-              <span className="text-black">${calculateTotalCost().toLocaleString()}</span>
-            </div>
-          </div>
+          <div className="border-t border-yellow-300 pt-4"> 
+            <div className={`${LAYOUT_CLASSES.flexBetween} text-lg font-semibold`}> 
+              <span className="text-yellow-300">Total Cost:</span> 
+              <span className="text-white">${calculateTotalCost().toLocaleString()}</span> 
+            </div> 
+          </div> 
 
-          <button className={`${BUTTON_CLASSES.primary} mt-4`}>
-            Request Quote
-          </button>
-        </>
-      )}
+          <button className={`${BUTTON_CLASSES.primary} mt-4`}> 
+            Request Quote 
+          </button> 
+        </> 
+      )} 
 
-      {!selectedCountry && (
-        <p className={TEXT_CLASSES.placeholder}>Select a country to see order breakdown</p>
-      )}
-    </div>
+      {!selectedCountry && ( 
+        <p className={TEXT_CLASSES.placeholder}>Select a country to see order breakdown</p> 
+      )} 
+    </div> 
   )
 }
 
-export default OrderSummary 
+export default OrderSummary

--- a/src/styles/classes.js
+++ b/src/styles/classes.js
@@ -2,83 +2,83 @@
 
 export const INPUT_CLASSES = {
   // Standard text/number inputs
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white border border-pink-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500",
   
   // Small inputs (like quantity in attachments)
-  small: "w-16 bg-white border border-gray-300 rounded px-2 py-1 text-gray-900 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black placeholder-gray-400"
+  small: "w-16 bg-white border border-pink-300 rounded px-2 py-1 text-gray-900 text-sm focus:outline-none focus:ring-1 focus:ring-pink-500 focus:border-pink-500 placeholder-pink-200"
 }
 
 export const SELECT_CLASSES = {
   // Standard dropdown selects
-  base: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black",
+  base: "w-full bg-white border border-pink-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500",
   
   // Large selects (like country selector)
-  large: "w-full bg-white border border-gray-300 rounded-lg px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black"
+  large: "w-full bg-white border border-pink-300 rounded-lg px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500"
 }
 
 export const BUTTON_CLASSES = {
-  // Primary black button
-  primary: "w-full bg-black hover:bg-gray-800 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
+  // Primary vibrant button with psychedelic gradient
+  primary: "w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md",
   
   // Toggle button (inactive state)
-  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-gray-600 hover:text-gray-900",
+  toggle: "px-3 py-1 text-xs font-medium rounded transition-all text-pink-300 hover:text-pink-100",
   
   // Toggle button (active state)
-  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-black text-white shadow-sm"
+  toggleActive: "px-3 py-1 text-xs font-medium rounded transition-all bg-pink-500 text-white shadow-sm"
 }
 
 export const CONTAINER_CLASSES = {
-  // Main card container
-  card: "bg-white rounded-lg p-6 shadow-sm border border-gray-200",
+  // Main card container with a neon border
+  card: "bg-white rounded-lg p-6 shadow-sm border border-pink-300",
   
-  // Sub-container (like attachment items)
-  subCard: "bg-gray-50 rounded-lg p-4 border border-gray-200",
+  // Sub-container (like attachment items) with soft pink background
+  subCard: "bg-pink-50 rounded-lg p-4 border border-pink-200",
   
-  // Small item containers (like breakdown items)
-  item: "bg-gray-50 rounded p-3 text-sm border border-gray-200",
+  // Small item containers (like breakdown items) with soft pink background
+  item: "bg-pink-50 rounded p-3 text-sm border border-pink-200",
   
   // Toggle button container
-  toggleContainer: "flex bg-gray-100 rounded-lg p-1 border border-gray-200"
+  toggleContainer: "flex bg-pink-100 rounded-lg p-1 border border-pink-200"
 }
 
 export const TEXT_CLASSES = {
   // Main headings
-  heading: "text-xl font-semibold text-gray-900 mb-4",
+  heading: "text-xl font-semibold text-white mb-4",
   
   // Page title
-  title: "text-4xl font-bold text-gray-900 mb-2",
+  title: "text-4xl font-bold text-white mb-2",
   
   // Subtitle
-  subtitle: "text-gray-600",
+  subtitle: "text-yellow-200",
   
   // Section labels
-  label: "block text-sm font-medium text-gray-700 mb-2",
+  label: "block text-sm font-medium text-pink-700 mb-2",
   
   // Sub-headings
-  subHeading: "font-medium text-gray-700 mb-2",
+  subHeading: "font-medium text-pink-700 mb-2",
   
   // Price text
-  price: "text-black font-semibold",
+  price: "text-pink-800 font-semibold",
   
   // Small descriptive text
-  description: "text-sm text-gray-600",
+  description: "text-sm text-yellow-600",
   
   // Small detail text
-  detail: "text-gray-600 text-xs",
+  detail: "text-pink-600 text-xs",
   
   // Product/item names
-  itemName: "text-gray-900 font-medium",
+  itemName: "text-purple-800 font-medium",
   
   // SKU text
-  sku: "text-gray-900 font-mono text-xs font-medium",
+  sku: "text-blue-900 font-mono text-xs font-medium",
   
   // Placeholder/empty state text
-  placeholder: "text-gray-500 text-center"
+  placeholder: "text-pink-300 text-center"
 }
 
 export const LAYOUT_CLASSES = {
-  // Main page container
-  page: "min-h-screen bg-gray-50 p-4",
+  // Main page container with a psychedelic gradient background
+  page: "min-h-screen bg-gradient-to-br from-purple-400 via-pink-500 to-red-500 p-4",
   
   // Content wrapper
   wrapper: "max-w-6xl mx-auto",
@@ -103,4 +103,4 @@ export const LAYOUT_CLASSES = {
   flexBetween: "flex justify-between items-center",
   flexStart: "flex items-start gap-4",
   flexCenter: "flex items-center gap-2"
-} 
+}


### PR DESCRIPTION
This pull request was created by the AI Assistant.

**Objective:** Can you make the interface brighter with psychadelic colors

**Branch:** ai-dev/you-make-interface-brighter-psychadelic
**Iterations:** 19

**Files Changed:**
• `src/styles/classes.js` - updated
• `src/components/OrderSummary.jsx` - updated

**Change Details:**
• src/styles/classes.js:
  - Updated color definitions to incorporate bright, psychedelic color schemes.
  - Modified background and accent colors to use vibrant gradients and high-contrast hues.
  - Adjusted styling rules to ensure the interface appears brighter and more energetic.

• src/components/OrderSummary.jsx:
  - Integrated the new style classes from classes.js into the component.
  - Updated component elements to reflect the brighter, psychedelic color scheme.
  - Ensured that text and background elements emphasize the updated aesthetic for enhanced visual appeal.

Please review the changes before merging.